### PR TITLE
Feature/update to net6

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,8 +2,7 @@ name: Test Build
 
 on: 
   push:
-    branches:
-      - "master"
+  pull_request:
 
 jobs:
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -360,3 +360,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Rider
+.idea/

--- a/src/Bottom.Bench/Bottom.Bench.csproj
+++ b/src/Bottom.Bench/Bottom.Bench.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bottom.CLI/Bottom.CLI.csproj
+++ b/src/Bottom.CLI/Bottom.CLI.csproj
@@ -2,15 +2,16 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Bottom.CLI</RootNamespace>
     <StartupObject>Bottom.CLI.Program</StartupObject>
-    <Version>3.0.0.0</Version>
+    <Version>6.0.0.0</Version>
     <AssemblyName>Bottom.CLI</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bottom.CLI/Program.cs
+++ b/src/Bottom.CLI/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.CommandLine;
 using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using System.IO;
 using System.Text;
 

--- a/src/Bottom.UnitTest/Bottom.UnitTest.csproj
+++ b/src/Bottom.UnitTest/Bottom.UnitTest.csproj
@@ -1,16 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
-    <PackageReference Include="coverlet.collector" Version="1.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bottom/Bottom.csproj
+++ b/src/Bottom/Bottom.csproj
@@ -1,17 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Bottom</AssemblyName>
     <RootNamespace>Bottom</RootNamespace>
-    <Version>3.0.0</Version>
+    <Version>6.0.0</Version>
     <PackageId>Bottom.NET</PackageId>
     <Authors>Bottom Software Foundation</Authors>
     <Product>Bottom.NET</Product>
     <Description>Bottom encoding utility functions for .NET</Description>
-    <Copyright>2021</Copyright>
+    <Copyright>2023</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <AssemblyVersion>3.0.0.0</AssemblyVersion>
+    <AssemblyVersion>6.0.0.0</AssemblyVersion>
     <PackageProjectUrl>https://github.com/bottom-software-foundation/bottom-dotnet/</PackageProjectUrl>
     <PackageIcon>logo.png</PackageIcon>
     <RepositoryUrl>https://github.com/bottom-software-foundation/bottom-dotnet/</RepositoryUrl>


### PR DESCRIPTION
This package does not load under net6 or net 7.

I choose net6 instead of net7 since net6 is the LTS, but let me know if you would prefer to update directly to net7.

There was only one code change necessary for this to compile and that is that the `CommandHandler` class is now on a separate NuGet package, so I added that too.

Also I updated the test workflow in order to test in other branches, and on pull requests.

Thanks and let me know what you think